### PR TITLE
dashboard login should work now

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,43 @@
 # Messaging credentials 
 
-TWILIO_SID=gyguygutfutf  # Twilio account ID 
-TWILIO_SID_TEST=jftjygygjgjgy # Twilio test account ID 
+TWILIO_SID=gyguygutfutf  
+# Twilio account ID 
+TWILIO_SID_TEST=jftjygygjgjgy 
+# Twilio test account ID 
 
-TWILIO_TOKEN=futfututf # Twilio auth token 
-TWILIO_TOKEN_TEST=jgygjygjfyjf # Twilio test auth token 
+TWILIO_TOKEN=futfututf 
+# Twilio auth token 
+TWILIO_TOKEN_TEST=jgygjygjfyjf 
+# Twilio test auth token 
 
-RESPONDER_PHONE=+16666666666 # The phone number that button press alerts will be sent to 
-RESPONDER_PHONE_TEST=+16666666666 # The phone number that button press alerts will be sent to when testing 
+RESPONDER_PHONE=+16666666666 
+# The phone number that button press alerts will be sent to 
+RESPONDER_PHONE_TEST=+16666666666 
+# The phone number that button press alerts will be sent to when testing 
 
-STAFF_PHONE=+16666666666 # The phone number that unresponded button press alerts will be sent to
-STAFF_PHONE_TEST=+16666666666 # The phone number that unresponded button press alerts will be sent to when testing
+STAFF_PHONE=+16666666666 
+# The phone number that unresponded button press alerts will be sent to
+STAFF_PHONE_TEST=+16666666666 
+# The phone number that unresponded button press alerts will be sent to when testing
 
-DB_NAME=db # The name of the database that completed button presses will be logged to  
+DB_NAME=db 
+# The name of the database that completed button presses will be logged to  
 DB_NAME_TEST=db 
 
-STATE_FILENAME=stateName # The name of the JSON file the ongoing requests will be saved to
+STATE_FILENAME=stateName 
+# The name of the JSON file the ongoing requests will be saved to
 STATE_FILENAME_TEST=stateName
 
-USERNAME=username # The username for logging into the dashboard
-USERNAME_TEST=username
+WEB_USERNAME=username 
+# The username for logging into the dashboard
+WEB_USERNAME_TEST=username
 
-PASSWORD=password # Password for logging into the dashboard
+PASSWORD=password 
+# Password for logging into the dashboard
 PASSWORD_TEST=password
 
-SECRET=secret # Cookie secret
+SECRET=secret 
+# Cookie secret
 SECRET_TEST=secret
 
 

--- a/server.js
+++ b/server.js
@@ -232,7 +232,7 @@ app.route('/login')
         var username = req.body.username,
             password = req.body.password;
 
-        if ((username == getEnvVar('USERNAME')) && (password == getEnvVar('PASSWORD'))) {
+        if ((username === getEnvVar('WEB_USERNAME')) && (password === getEnvVar('PASSWORD'))) {
         	req.session.user = username;
         	res.redirect('/dashboard');
         } else {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -221,4 +221,28 @@ let stateData = allStateData[defaultBody.PhoneNumber];
 	after(() => {
 		fs.writeFileSync('./' + stateFilename + '.json', '{}');
 	});
+
+	describe('POST request: button replacement', () => {
+
+		beforeEach(() => {
+  			delete require.cache[require.resolve('../server.js')];
+  			app = require('../server.js');
+			fs.writeFileSync('./' + stateFilename + '.json', '{}');
+		});
+
+		it('should return ok to a valid request', async () => {
+			let response = await chai.request(app).post('/replace').send(twilioMessageBody);
+			expect(response).to.have.status(200);
+		});
+
+
+		afterEach(function () {
+		    app.close();
+		});
+
+	});
+
+	after(() => {
+		fs.writeFileSync('./' + stateFilename + '.json', '{}');
+	});
 });


### PR DESCRIPTION
@mariocimet turns out the login issue was due to the fact that USERNAME is a built-in env variable on the server which is *not* overridden by the .env file - I've changed the name of the variable and updated the example .env to reflect that 