### PR TITLE
Run all tests in Travis on Xenial Ubuntu dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,17 @@ dist: xenial
 install:
   - npm install
 
+# install database
+services:
+  - postgresql
+
+# setup database
+before_script:
+  - psql -c "CREATE ROLE $PG_USER PASSWORD '$PG_PASSWORD' LOGIN"
+  - createdb -O $PG_USER $PG_USER
+  - psql -d $PG_USER -c 'CREATE EXTENSION IF NOT EXISTS "pgcrypto"'
+  - PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -d $PG_USER -f ./db/setup.sql
+
 # run unit tests
 script:
 - sudo env "PATH=$PATH" npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js: "node"
+
+# OS
+dist: xenial
+
+# install dependencies
+install:
+  - npm install
+
+# run unit tests
+script:
+- sudo env "PATH=$PATH" npm run test


### PR DESCRIPTION
It works!
Here are the results on this branch: https://travis-ci.com/bravetechnologycoop/BraveChatbot/builds/102576928

Specified to use the Xenial Ubuntu distribution because that is what is running on the real machine.

I defined all the `_TEST` environment variables in the Travis repository settings (as described here:  https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings) as well as the PG_USER and PG_PASSWORD environment variables.

For `PG_USER` and `PG_PASSWORD`, I just gave dummy values instead of the real ones since they are just used by the temporary DB created on the Travis machine.

There was a problem with running `sudo npm run test` because the `PATH` variable is reset as soon as you use `sudo`. We used this workaround to make it work: https://github.com/travis-ci/travis-ci/issues/1350#issuecomment-313239849